### PR TITLE
Feature/injected mappings

### DIFF
--- a/TinYard Tests/Tests/ContextTests.cs
+++ b/TinYard Tests/Tests/ContextTests.cs
@@ -146,16 +146,21 @@ namespace TinYard.Tests
 
             TestInjectable testInjectable = new TestInjectable();
 
-            //Ensure it's 0
-            Assert.AreEqual(default(int), testInjectable.Value);
+            int testValue = 5;
+            int preInjectValue = testInjectable.Value;
+
+            Assert.IsTrue(preInjectValue != testValue);
 
             //Map an int value so that we can test if it's changed later
-            _context.Mapper.Map<int>().ToValue(5);
+            _context.Mapper.Map<int>().ToValue(testValue);
 
             //Injector should run on this happening
             _context.Mapper.Map<TestInjectable>().ToValue(testInjectable);
 
-            Assert.AreEqual(5, testInjectable.Value);
+            int postInjectValue = testInjectable.Value;
+
+            Assert.IsTrue(preInjectValue != postInjectValue);
+            Assert.AreEqual(testValue, postInjectValue);
         }
     }
 }

--- a/TinYard Tests/Tests/ContextTests.cs
+++ b/TinYard Tests/Tests/ContextTests.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TinYard.API.Interfaces;
+using TinYard.Framework.API.Interfaces;
 using TinYard.Impl.Exceptions;
 using TinYard.Tests.MockClasses;
+using TinYard_Tests.TestClasses;
 
 namespace TinYard.Tests
 {
@@ -29,6 +31,10 @@ namespace TinYard.Tests
             Assert.IsInstanceOfType(_context, typeof(IContext));
         }
 
+        //
+        //  Extensions and Configs
+        //
+
         [TestMethod]
         public void Context_Installs_Extension()
         {
@@ -36,63 +42,6 @@ namespace TinYard.Tests
             _context.Install(_testExtension);
             _context.Initialize();
             //Assert nothing, if it doesn't throw it's a success
-        }
-
-        [TestMethod]
-        public void Context_Configures_Extension()
-        {
-            _testExtension = new TestExtension();
-            _context.Install(_testExtension).Configure(new TestConfig());
-            _context.Initialize();
-            //Assert nothing, if it doesn't throw it's a success
-        }
-
-        [TestMethod]
-        public void Context_Provides_Config_Injections()
-        {
-            _testExtension = new TestExtension();
-            TestConfig config = new TestConfig();
-            _context.Install(_testExtension).Configure(config);
-            _context.Initialize();
-
-            Assert.AreEqual(_context, config.context);
-        }
-
-        [TestMethod]
-        public void Context_Installs_Bundle()
-        {
-            IBundle testBundle = new TestBundle();
-            _context.Install(testBundle);
-            _context.Initialize();
-
-            //Assert nothing, if it doesn't throw it's a success
-        }
-
-        [TestMethod]
-        public void Context_Initializes_With_No_Errors()
-        {
-            //Assert nothing, if it doesn't throw it's a success
-            _context.Initialize();
-        }
-
-        [TestMethod]
-        public void Context_Passes_Itself_To_Extension_On_Install()
-        {
-            _testExtension = new TestExtension();
-            _context.Install(_testExtension);
-            _context.Initialize();
-
-            Assert.AreEqual(_context, _testExtension.context);
-        }
-
-        [TestMethod]
-        public void Context_Throws_On_Multiple_Initializations()
-        {
-            Assert.ThrowsException<ContextException>(() =>
-            {
-                _context.Initialize();
-                _context.Initialize();
-            });
         }
 
         [TestMethod]
@@ -110,6 +59,64 @@ namespace TinYard.Tests
         }
 
         [TestMethod]
+        public void Context_Passes_Itself_To_Extension_On_Install()
+        {
+            _testExtension = new TestExtension();
+            _context.Install(_testExtension);
+            _context.Initialize();
+
+            Assert.AreEqual(_context, _testExtension.context);
+        }
+
+        [TestMethod]
+        public void Context_Configures_Extension()
+        {
+            _testExtension = new TestExtension();
+            _context.Install(_testExtension).Configure(new TestConfig());
+            _context.Initialize();
+            //Assert nothing, if it doesn't throw it's a success
+        }
+
+        //
+        //  Bundles
+        //
+
+        [TestMethod]
+        public void Context_Installs_Bundle()
+        {
+            IBundle testBundle = new TestBundle();
+            _context.Install(testBundle);
+            _context.Initialize();
+
+            //Assert nothing, if it doesn't throw it's a success
+        }
+
+        //
+        //  Initialisations
+        //
+
+        [TestMethod]
+        public void Context_Initializes_With_No_Errors()
+        {
+            //Assert nothing, if it doesn't throw it's a success
+            _context.Initialize();
+        }
+
+        [TestMethod]
+        public void Context_Throws_On_Multiple_Initializations()
+        {
+            Assert.ThrowsException<ContextException>(() =>
+            {
+                _context.Initialize();
+                _context.Initialize();
+            });
+        }
+
+        //
+        //  Context Members
+        //
+
+        [TestMethod]
         public void Context_Has_Mapper()
         {
             Assert.IsNotNull(_context.Mapper);
@@ -119,6 +126,36 @@ namespace TinYard.Tests
         public void Context_Has_Injector()
         {
             Assert.IsNotNull(_context.Injector);
+        }
+
+        [TestMethod]
+        public void Context_Provides_Config_Injections()
+        {
+            _testExtension = new TestExtension();
+            TestConfig config = new TestConfig();
+            _context.Install(_testExtension).Configure(config);
+            _context.Initialize();
+
+            Assert.AreEqual(_context, config.context);
+        }
+
+        [TestMethod]
+        public void Context_Injects_Values_Mapped()
+        {
+            _context.Initialize();
+
+            TestInjectable testInjectable = new TestInjectable();
+
+            //Ensure it's 0
+            Assert.AreEqual(default(int), testInjectable.Value);
+
+            //Map an int value so that we can test if it's changed later
+            _context.Mapper.Map<int>().ToValue(5);
+
+            //Injector should run on this happening
+            _context.Mapper.Map<TestInjectable>().ToValue(testInjectable);
+
+            Assert.AreEqual(5, testInjectable.Value);
         }
     }
 }

--- a/TinYard/Framework/API/Interfaces/IMapper.cs
+++ b/TinYard/Framework/API/Interfaces/IMapper.cs
@@ -1,14 +1,18 @@
 ﻿using System;
+using System.Collections.Generic;
 using TinYard.Impl.VO;
 
 namespace TinYard.API.Interfaces
 {
     public interface IMapper
     {
+        event Action<IMappingObject> OnValueMapped;
+
         IMappingObject Map<T>();
 
         IMappingObject GetMapping<T>();
         IMappingObject GetMapping(Type type);
+        IReadOnlyList<IMappingObject> GetAllMappings();
 
         object GetMappingValue<T>();
         object GetMappingValue(Type type);

--- a/TinYard/Framework/Impl/Context.cs
+++ b/TinYard/Framework/Impl/Context.cs
@@ -5,6 +5,7 @@ using TinYard.Framework.API.Interfaces;
 using TinYard.Framework.Impl.Injectors;
 using TinYard.Impl.Exceptions;
 using TinYard.Impl.Mappers;
+using TinYard.Impl.VO;
 
 namespace TinYard
 {
@@ -47,7 +48,10 @@ namespace TinYard
             _extensionsToInstall = new List<IExtension>();
             _configsToInstall = new List<IConfig>();
 
+            //Create our mapper, then add a hook so that we can inject into anything that gets mapped
             _mapper = new ValueMapper();
+            _mapper.OnValueMapped += InjectValueMapper;
+
             _injector = new TinYardInjector(this);
 
             //Ensure the context, mapper and injector are mapped for injection needs
@@ -182,6 +186,11 @@ namespace TinYard
             }
 
             _configsToInstall.Clear();
+        }
+
+        private void InjectValueMapper(IMappingObject mappingObject)
+        {
+            _injector.Inject(mappingObject.MappedValue);
         }
     }
 }

--- a/TinYard/Framework/Impl/Mappers/ValueMapper.cs
+++ b/TinYard/Framework/Impl/Mappers/ValueMapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using TinYard.API.Interfaces;
 using TinYard.Impl.VO;
@@ -8,11 +9,17 @@ namespace TinYard.Impl.Mappers
 {
     public class ValueMapper : IMapper
     {
+        public event Action<IMappingObject> OnValueMapped;
+
         private List<IMappingObject> _mappingObjects = new List<IMappingObject>();
 
         public IMappingObject Map<T>()
         {
             var mappingObj = new MappingObject();
+
+            if (OnValueMapped != null)
+                mappingObj.OnValueMapped += ( mapping ) => OnValueMapped.Invoke(mapping);
+
             _mappingObjects.Add(mappingObj);
             return mappingObj.Map<T>();
         }
@@ -29,6 +36,11 @@ namespace TinYard.Impl.Mappers
             var value = _mappingObjects.First(mapping => mapping.MappedType.IsAssignableFrom(type));
 
             return value;
+        }
+
+        public IReadOnlyList<IMappingObject> GetAllMappings()
+        {
+            return _mappingObjects.AsReadOnly();
         }
 
         public object GetMappingValue<T>()

--- a/TinYard/Framework/Impl/VO/IMappingObject.cs
+++ b/TinYard/Framework/Impl/VO/IMappingObject.cs
@@ -7,6 +7,8 @@ namespace TinYard.Impl.VO
         Type MappedType { get; }
         object MappedValue { get; }
 
+        event Action<IMappingObject> OnValueMapped;
+
         IMappingObject Map<T>();
 
         IMappingObject ToValue<T>();

--- a/TinYard/Framework/Impl/VO/MappingObject.cs
+++ b/TinYard/Framework/Impl/VO/MappingObject.cs
@@ -10,6 +10,8 @@ namespace TinYard.Impl.VO
         public object MappedValue { get { return _mappedValue; } }
         private object _mappedValue;
 
+        public event Action<IMappingObject> OnValueMapped;
+
         public IMappingObject Map<T>()
         {
             _mappedType = typeof(T);
@@ -20,13 +22,19 @@ namespace TinYard.Impl.VO
         public IMappingObject ToValue<T>()
         {
             _mappedValue = typeof(T);
-            
+
+            if (OnValueMapped != null)
+                OnValueMapped.Invoke(this);
+
             return this;
         }
 
         public IMappingObject ToValue(object value)
         {
             _mappedValue = value;
+
+            if (OnValueMapped != null)
+                OnValueMapped.Invoke(this);
 
             return this;
         }


### PR DESCRIPTION
Added an event that is fired when an `IMappingObject` has the value set.

Added another event on `IMapper` that is simply an extension of this, to provide access to these `IMappingObject`'s. Take a look at `ValueMapper.cs` and `MappingObject.cs` changes to see what I mean here.

This event is hooked into in the `IMapper` used in the `Context`, so that the `IInjector` can inject into this value that was mapped.

See the new test in `ContextTests.cs`, to see how an example of this working.

Also added a `GetAllMappings` function to `IMapper`.

Resolves #18 